### PR TITLE
feat: email notifications for pipeline events

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,3 +123,37 @@ jobs:
           print('Pipeline state updated.')
           "
           fi
+
+  notify:
+    needs: [deploy, smoke-test, update-state]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pydantic-settings python-dotenv
+      - name: Send deploy notification
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          ALERT_EMAIL_FROM: ${{ secrets.ALERT_EMAIL_FROM }}
+          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO }}
+        run: |
+          if [ "${{ needs.deploy.result }}" = "failure" ] || [ "${{ needs.smoke-test.result }}" = "failure" ]; then
+            STATUS="failure"
+            EVENT="Deploy Failed"
+            DETAILS="Version: ${{ inputs.model_version }} | Deploy: ${{ needs.deploy.result }} | Smoke test: ${{ needs.smoke-test.result }} | State update: ${{ needs.update-state.result }}"
+          else
+            STATUS="success"
+            EVENT="Deploy Complete"
+            DETAILS="Version: ${{ inputs.model_version }} deployed successfully. Smoke test passed."
+          fi
+          python scripts/notify.py \
+            --channel email \
+            --event "$EVENT" \
+            --status "$STATUS" \
+            --details "$DETAILS | Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/model-comparison.yml
+++ b/.github/workflows/model-comparison.yml
@@ -189,3 +189,38 @@ jobs:
         with:
           name: model-comparison
           path: /tmp/model_comparison/
+
+  # ── Notifications ───────────────────────────────────────────────────────
+  notify:
+    needs: [eval-qwen7b, eval-gemini, model-selection]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pydantic-settings python-dotenv
+      - name: Send model comparison notification
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          ALERT_EMAIL_FROM: ${{ secrets.ALERT_EMAIL_FROM }}
+          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO }}
+        run: |
+          if [ "${{ needs.model-selection.result }}" = "failure" ] || [ "${{ needs.eval-qwen7b.result }}" = "failure" ] || [ "${{ needs.eval-gemini.result }}" = "failure" ]; then
+            STATUS="failure"
+            EVENT="Model Comparison Failed"
+            DETAILS="Eval Qwen7B: ${{ needs.eval-qwen7b.result }} | Eval Gemini: ${{ needs.eval-gemini.result }} | Selection: ${{ needs.model-selection.result }}"
+          else
+            STATUS="success"
+            EVENT="Model Comparison Complete"
+            DETAILS="Winner: ${{ needs.model-selection.outputs.winner }} | Promoted: ${{ needs.model-selection.outputs.promoted }}"
+          fi
+          python scripts/notify.py \
+            --channel email \
+            --event "$EVENT" \
+            --status "$STATUS" \
+            --details "$DETAILS | Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/model-evaluation.yml
+++ b/.github/workflows/model-evaluation.yml
@@ -116,3 +116,35 @@ jobs:
             --gcs-input "${{ secrets.EVAL_GCS_TEST_PATH }}" \
             --bucket "${{ secrets.GCS_BUCKET_NAME }}" \
             --project "${{ secrets.GCP_PROJECT_ID }}"
+
+      - name: Send threshold/bias failure notification
+        if: failure()
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          ALERT_EMAIL_FROM: ${{ secrets.ALERT_EMAIL_FROM }}
+          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO }}
+        run: |
+          python scripts/notify.py \
+            --channel email \
+            --event "Model Evaluation Failed (threshold or bias check)" \
+            --status failure \
+            --details "The model failed validation gates. Check thresholds and bias report. | Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Send evaluation success notification
+        if: success()
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          ALERT_EMAIL_FROM: ${{ secrets.ALERT_EMAIL_FROM }}
+          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO }}
+        run: |
+          python scripts/notify.py \
+            --channel email \
+            --event "Model Evaluation Passed" \
+            --status success \
+            --details "All thresholds and bias checks passed. | Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/model-training.yml
+++ b/.github/workflows/model-training.yml
@@ -147,3 +147,37 @@ jobs:
           print(f'Registered: {result}')
           "
           fi
+
+  notify:
+    needs: [train, log-mlflow, register]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pydantic-settings python-dotenv
+      - name: Send training notification
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          ALERT_EMAIL_FROM: ${{ secrets.ALERT_EMAIL_FROM }}
+          ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO }}
+        run: |
+          if [ "${{ needs.train.result }}" = "failure" ]; then
+            STATUS="failure"
+            EVENT="Training Failed"
+            DETAILS="Model version: ${{ needs.train.outputs.model_version }} | Train: ${{ needs.train.result }} | MLflow: ${{ needs.log-mlflow.result }} | Register: ${{ needs.register.result }}"
+          else
+            STATUS="success"
+            EVENT="Training Complete"
+            DETAILS="Model version: ${{ needs.train.outputs.model_version }} | GCS: ${{ needs.train.outputs.model_gcs_uri }} | All steps passed"
+          fi
+          python scripts/notify.py \
+            --channel email \
+            --event "$EVENT" \
+            --status "$STATUS" \
+            --details "$DETAILS | Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ Given a seed paper ID, this pipeline crawls the Semantic Scholar citation graph,
 9. [Model Comparison & Selection](#model-comparison--selection)
 10. [Experiment Tracking (MLflow)](#experiment-tracking-mlflow)
 11. [Model Registry & Rollback](#model-registry--rollback)
-12. [Error Handling](#error-handling)
-13. [Tracking & Logging](#tracking--logging)
-14. [Running Tests](#running-tests)
-15. [Data Versioning (DVC)](#data-versioning-dvc)
-16. [Project Structure](#project-structure)
-17. [Prerequisites](#prerequisites)
-18. [Setup & Reproducibility](#setup--reproducibility)
-19. [Running the Pipeline](#running-the-pipeline)
-20. [Configuration Reference](#configuration-reference)
+12. [Notifications & Alerts](#notifications--alerts)
+13. [Error Handling](#error-handling)
+14. [Tracking & Logging](#tracking--logging)
+15. [Running Tests](#running-tests)
+16. [Data Versioning (DVC)](#data-versioning-dvc)
+17. [Project Structure](#project-structure)
+18. [Prerequisites](#prerequisites)
+19. [Setup & Reproducibility](#setup--reproducibility)
+20. [Running the Pipeline](#running-the-pipeline)
+21. [Configuration Reference](#configuration-reference)
 
 ---
 
@@ -473,6 +474,84 @@ Programmatic rollback: `src/registry/rollback.py` — `rollback_model()`, `get_r
 
 ---
 
+## Notifications & Alerts
+
+Email notifications are sent via SMTP for pipeline failures, training completion, model validation results, and bias check outcomes. All notifications use `scripts/notify.py` — a CLI wrapper around `src/utils/email_service.py`.
+
+### Coverage
+
+| Pipeline | Event | When |
+|---|---|---|
+| **CI** (`ci.yml`) | Lint / typecheck / test / DAG validation failure | Any job fails |
+| **Model Training** (`model-training.yml`) | Training complete or failed | Always (after train + log + register) |
+| **Model Evaluation** (`model-evaluation.yml`) | Threshold gate or bias check failure | Step fails |
+| **Model Evaluation** (`model-evaluation.yml`) | All evaluation gates passed | All steps succeed |
+| **Model Comparison** (`model-comparison.yml`) | Selection results (winner + promoted status) | Always (after eval + selection) |
+| **Deploy** (`deploy.yml`) | Deploy success or failure (includes smoke test) | Always (after deploy + smoke + state) |
+| **Rollback** (`rollback.yml`) | Rollback result | Always |
+| **Airflow: compare_models** | Comparison complete or failed | `trigger_rule: all_success` / `one_failed` |
+| **Airflow: evaluate_performance** | Evaluation complete or failed | `trigger_rule: all_success` / `one_failed` |
+| **Airflow: research_lineage_pipeline** | Anomaly detection alerts (T9) | Anomalies detected |
+
+### How It Works
+
+All CI/CD notifications call the same script:
+
+```bash
+python scripts/notify.py \
+  --channel email \
+  --event "Training Complete" \
+  --status success \
+  --details "Model version: v20260324 | All steps passed"
+```
+
+The script reads SMTP credentials from environment variables and sends a formatted email via `EmailService`. If SMTP is not configured, the notification is silently skipped — the pipeline continues normally.
+
+Airflow DAGs use `BashOperator` tasks with `trigger_rule`:
+- `notify_success` — runs only when all upstream tasks succeed (`all_success`)
+- `notify_failure` — runs when any upstream task fails (`one_failed`)
+
+### Required Secrets (GitHub Actions)
+
+| Secret | Description |
+|---|---|
+| `SMTP_HOST` | SMTP server (default: `smtp.gmail.com`) |
+| `SMTP_PORT` | SMTP port (default: `587`) |
+| `SMTP_USER` | SMTP login (e.g. Gmail address) |
+| `SMTP_PASSWORD` | SMTP password (Gmail App Password) |
+| `ALERT_EMAIL_FROM` | Sender email address |
+| `ALERT_EMAIL_TO` | Recipient email address |
+
+For Airflow, set these as environment variables in `.env` or `docker-compose.yml`.
+
+### Gmail Setup
+
+1. Enable **2-Step Verification** on your Google account
+2. Go to `myaccount.google.com/apppasswords`
+3. Generate a 16-character App Password
+4. Use it as `SMTP_PASSWORD`
+
+### Testing Notifications via PR
+
+Push to the `feature/cicd-pipeline` branch (or any branch with an open PR to `main`). The workflows run in **validation mode** — no GPU costs, no live inference — but the notification steps still execute. If SMTP secrets are configured in the repo, you will receive emails for:
+
+- CI pass/fail
+- Model comparison selection results
+- Evaluation threshold/bias gate results
+- Training workflow completion
+
+If SMTP secrets are **not** configured, the notification steps log "Email not configured, skipping" and the workflow still passes.
+
+### Key Files
+
+| File | Purpose |
+|---|---|
+| `scripts/notify.py` | CLI entry point — supports `--channel email/slack/both` |
+| `src/utils/email_service.py` | `EmailService` class with SMTP send logic |
+| `src/utils/email_templates.py` | HTML email templates with alert levels (INFO, WARNING, ERROR, SUCCESS) |
+
+---
+
 ## Error Handling
 
 Each task raises typed exceptions from `src/utils/errors.py`:
@@ -620,16 +699,18 @@ dvc pull data/raw.dvc
 ├── .github/
 │   └── workflows/
 │       ├── ci.yml                     # Lint, typecheck, test, DAG validation
-│       ├── model-training.yml         # Modal training → MLflow → registry
-│       ├── model-evaluation.yml       # Inference + judge scoring + bias gates
-│       ├── deploy.yml                 # Modal deploy + smoke test + state update
-│       └── rollback.yml               # Rollback to previous model version
+│       ├── model-training.yml         # Modal training → MLflow → registry → notify
+│       ├── model-comparison.yml       # Multi-model eval → selection → notify
+│       ├── model-evaluation.yml       # Inference + judge scoring + bias gates → notify
+│       ├── deploy.yml                 # Modal deploy + smoke test + state update → notify
+│       └── rollback.yml               # Rollback to previous model version → notify
 │
 ├── dags/
 │   ├── research_lineage_pipeline.py   # Main 11-task citation pipeline DAG
 │   ├── fine_tuning_data_pipeline.py   # Fine-tuning data generation DAG (8 BashOperator tasks)
 │   ├── training_dag.py               # Model training DAG (Modal + MLflow logging)
-│   ├── evaluate_performance.py        # Evaluation DAG (inference + judge + bias)
+│   ├── evaluate_performance.py        # Evaluation DAG (inference + judge + bias + notify)
+│   ├── compare_models.py             # Multi-model comparison DAG (parallel eval + select + notify)
 │   └── retry_failed_pdfs_dag.py       # Standalone PDF retry DAG
 │
 ├── src/
@@ -647,6 +728,8 @@ dvc pull data/raw.dvc
 │   │   ├── config.py                  # Evaluation config
 │   │   ├── types.py                   # Evaluation types
 │   │   ├── model_client.py            # Model inference client
+│   │   ├── model_selection.py        # Composite scoring + model ranking
+│   │   ├── visualization.py          # Comparison charts (matplotlib) + HTML report
 │   │   └── gcs_utils.py              # GCS helpers for eval artifacts
 │   ├── registry/
 │   │   ├── artifact_registry.py       # GCS-based model registry (push, list, promote)
@@ -664,6 +747,7 @@ dvc pull data/raw.dvc
 │   │   ├── database_write.py          # T10 — PostgreSQL upsert
 │   │   ├── report_generation.py       # T11 — JSON statistics report
 │   │   ├── evaluation_task.py         # Evaluation step runner (inference, evaluate, bias_check)
+│   │   ├── model_selection_task.py   # Model selection CLI (select → viz → MLflow → promote)
 │   │   ├── pdf_upload_task.py         # Parallel branch — fetch + GCS upload
 │   │   ├── retry_failed_pdfs_task.py  # DAG 3 — retry failed PDF fetches
 │   │   └── lineage_pipeline.py        # Fine-tuning pipeline step runner (DAG 2)
@@ -673,7 +757,8 @@ dvc pull data/raw.dvc
 │       ├── errors.py                  # ValidationError, DataQualityError, APIError
 │       ├── id_mapper.py               # S2 ↔ ArXiv ID mapping
 │       ├── logging.py                 # Centralised logging — single get_logger entry point
-│       └── email_service.py           # SMTP email alert service
+│       ├── email_service.py           # SMTP email alert service
+│       └── email_templates.py        # HTML email templates with alert levels
 │
 ├── scripts/
 │   ├── modal_train.py                 # Modal training script (Qwen2.5-7B + LoRA on A100)

--- a/dags/compare_models.py
+++ b/dags/compare_models.py
@@ -197,6 +197,39 @@ with DAG(
         execution_timeout=timedelta(minutes=15),
     )
 
+    # ── Email notification on completion ──────────────────────────────────────
+
+    _NOTIFY_BASE = f"cd {PROJECT_ROOT} && PYTHONPATH={PROJECT_ROOT} python scripts/notify.py"
+
+    notify_success = BashOperator(
+        task_id="notify_success",
+        bash_command=(
+            _NOTIFY_BASE +
+            " --channel email"
+            " --event 'Model Comparison Complete (Airflow)'"
+            " --status success"
+            " --details 'All models evaluated and comparison uploaded to GCS.'"
+            " "
+        ),
+        trigger_rule="all_success",
+        execution_timeout=timedelta(minutes=5),
+    )
+
+    notify_failure = BashOperator(
+        task_id="notify_failure",
+        bash_command=(
+            _NOTIFY_BASE +
+            " --channel email"
+            " --event 'Model Comparison Failed (Airflow)'"
+            " --status failure"
+            " --details 'One or more evaluation or selection steps failed. Check Airflow logs.'"
+            " "
+        ),
+        trigger_rule="one_failed",
+        execution_timeout=timedelta(minutes=5),
+    )
+
     # ── Flow ─────────────────────────────────────────────────────────────────
 
     [eval_model_a, eval_model_b, eval_model_c] >> model_selection >> upload_comparison
+    upload_comparison >> [notify_success, notify_failure]

--- a/dags/evaluate_performance.py
+++ b/dags/evaluate_performance.py
@@ -151,5 +151,37 @@ with DAG(
         execution_timeout=timedelta(minutes=5),
     )
 
+    # ── Email notifications ──────────────────────────────────────────────────
+    _NOTIFY_BASE = f"cd {PROJECT_ROOT} && PYTHONPATH={PROJECT_ROOT} python scripts/notify.py"
+
+    notify_success = BashOperator(
+        task_id="notify_success",
+        bash_command=(
+            _NOTIFY_BASE +
+            " --channel email"
+            " --event 'Evaluation Complete (Airflow)'"
+            " --status success"
+            " --details 'Inference, evaluation, upload, and bias check all passed.'"
+            " "
+        ),
+        trigger_rule="all_success",
+        execution_timeout=timedelta(minutes=5),
+    )
+
+    notify_failure = BashOperator(
+        task_id="notify_failure",
+        bash_command=(
+            _NOTIFY_BASE +
+            " --channel email"
+            " --event 'Evaluation Failed (Airflow)'"
+            " --status failure"
+            " --details 'One or more evaluation steps failed. Check bias check and threshold logs.'"
+            " "
+        ),
+        trigger_rule="one_failed",
+        execution_timeout=timedelta(minutes=5),
+    )
+
     # ── Flow ──────────────────────────────────────────────────────────────────
     run_inference >> evaluate >> [upload_to_gcs, bias_check]
+    [upload_to_gcs, bias_check] >> [notify_success, notify_failure]


### PR DESCRIPTION
## Summary

- Add SMTP email notifications to all CI/CD workflows: model-training, model-comparison, model-evaluation, deploy
- Add notification tasks to Airflow DAGs: `compare_models`, `evaluate_performance` (success + failure with trigger rules)
- Document full notification coverage, setup, and testing in README

## Notification Coverage

| Pipeline | Event |
|---|---|
| CI | Lint/test/typecheck failure (existing) |
| Model Training | Training complete / failed |
| Model Evaluation | Threshold gate or bias check failure, success |
| Model Comparison | Selection results (winner + promoted), failure |
| Deploy | Deploy + smoke test success/failure |
| Rollback | Rollback result (existing) |
| Airflow: compare_models | Comparison complete / failed |
| Airflow: evaluate_performance | Evaluation complete / failed |

## Test plan

- [x] Verify all 6 workflows pass in PR validation mode
- [x] Check notification job logs show "Email not configured, skipping" (if SMTP secrets not set) or actual email sent
- [x] Validate DAG syntax passes in CI
- [ ] Confirm README renders correctly on GitHub
